### PR TITLE
Bump version for 2020.3 rebuild and upgrade intelliJ plugin to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+        
+#### 1.0.1
+
+- Rebuilt for 2020.3
 
 #### 1.0.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.4.18'
+    id 'org.jetbrains.intellij' version '0.5.0'
 }
 
 group 'com.ADMARIl'
-version '1.0.0'
+version '1.0.1'
 
 sourceCompatibility = 1.8
 

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -1,3 +1,7 @@
+<h4>1.0.1</h4>
+<ul>
+    <li>Rebuilt for Idea 2020.3</li>
+</ul>
 <h4>1.0.0</h4>
 <ul>
     <li>Changed merge conflict background, so it's easier to see.</li>


### PR DESCRIPTION
Quick an easy version bump. Added an entry to the changelog and bumped up the IntelliJ Gradle plugin to the most recent version.