### PR TITLE
Update gradle build for IDEs v2022.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id("java")
-    id("org.jetbrains.intellij") version "1.9.0"
+    id("org.jetbrains.intellij") version "1.10.1"
 }
 
 group 'com.ADMARIl'
-version '2.2.1'
+version '2.3.0'
 
 repositories {
     mavenCentral()
@@ -12,7 +12,7 @@ repositories {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set('LATEST-EAP-SNAPSHOT')
+    version.set('IC-2022.3')
 }
 
 tasks {
@@ -29,6 +29,6 @@ tasks {
     }
 
     runPluginVerifier {
-        ideVersions.set(["IC-2021.3.1"])
+        ideVersions.set(["IC-2022.3"])
     }
 }


### PR DESCRIPTION
These changes allowed me to build and run theme locally on WebStorm version 2022.3

If I am correct, then **Fixes #24** 